### PR TITLE
Update ovsdb to v1.0.5 with OVS 3.x+ version detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 )
+
+replace github.com/greenpau/ovsdb => github.com/lucadelmonte/ovsdb v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/greenpau/ovsdb v1.0.4 h1:ekvfucZr5Dl/bYgcz6+nido4lSBDqG5kqLFUv55BqvQ=
-github.com/greenpau/ovsdb v1.0.4/go.mod h1:eZ72kooepm3wDa9o4YgmfEmbFCeibzSYrrZazwaopxo=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -21,6 +19,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/lucadelmonte/ovsdb v1.0.5 h1:keGS679Z44mTiTTUyahJQLNaJK9UmNtk3m78Y4KH/gI=
+github.com/lucadelmonte/ovsdb v1.0.5/go.mod h1:eZ72kooepm3wDa9o4YgmfEmbFCeibzSYrrZazwaopxo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
- Use lucadelmonte/ovsdb@v1.0.5
- Adds intelligent version detection for OVS 3.x+
- Queries ovs-appctl, schema, and OS for version info
- Improves observability and reduces error logging